### PR TITLE
Rescued tourist fix

### DIFF
--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -600,7 +600,7 @@ namespace LifeSupport
 
         private void RemoveGrouchiness(ProtoCrewMember c, LifeSupportStatus k)
         {
-            if (c.type == ProtoCrewMember.KerbalType.Tourist && k.IsGrouchy)
+            if (k.IsGrouchy)
             {
                 string msg = string.Format("{0} has returned to duty", c.name);
                 ScreenMessages.PostScreenMessage(msg, 5f, ScreenMessageStyle.UPPER_CENTER);

--- a/Source/USILifeSupport/USILifeSupport.csproj
+++ b/Source/USILifeSupport/USILifeSupport.csproj
@@ -75,7 +75,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>"D:\Games\pdb2mdb\pdb2mdb.exe" "$(TargetFileName)"
+    <PostBuildEvent Condition="'$(OS)' != 'Unix'">"D:\Games\pdb2mdb\pdb2mdb.exe" "$(TargetFileName)"
 </PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
To fix MKS issue #1265.

Upon recovery of a rescued Kerbal, KSP probably sets its type to "Crew", which interferes with what USI-LS does when the Kerbal gets grouchy (setting its type to "Tourist").

This simply allows reverting a Kerbal to its old trait, even when its type is not Tourist.