### PR TITLE
Fix CalculateVesselHabMultiplier when unmanned

### DIFF
--- a/Source/USILifeSupport/LifeSupportManager.cs
+++ b/Source/USILifeSupport/LifeSupportManager.cs
@@ -472,13 +472,14 @@ namespace LifeSupport
 
         public static double CalculateVesselHabMultiplier(Vessel v, int numCrew)
         {
+            if (numCrew == 0)
+                return 0d;
             var habMulti = 0d;
             var habMods = v.FindPartModulesImplementing<ModuleHabitation>();
             var count = habMods.Count;
             for (int i = 0; i < count; ++i)
             {
                 var hab = habMods[i];
-
                 habMulti += (hab.HabMultiplier * Math.Min(1, hab.CrewCapacity / numCrew));
             }
             return habMulti;


### PR DESCRIPTION
Return 0 instead of NaN.
In some circumstances, this number was used by ModuleLifeSupportExtender (not sure it should), and then produced a Nan EfficiencyBonus. The game then probably used it to run a conversion step, leading to all kind of physical-impacting problems.

Fixes MKS issue #1276