### PR TITLE
Don't hard-code day and year lengths

### DIFF
--- a/Source/USILifeSupport/LifeSupportUtilities.cs
+++ b/Source/USILifeSupport/LifeSupportUtilities.cs
@@ -8,12 +8,12 @@ namespace LifeSupport
 
         public static double SecondsPerDay()
         {
-            return GameSettings.KERBIN_TIME ? 21600d : 86400d;
+            return KSPUtil.dateTimeFormatter.Day;
         }
 
         public static double SecondsPerYear()
         {
-            return GameSettings.KERBIN_TIME ? SecondsPerDay() * 426d : SecondsPerDay() * 365d;
+            return KSPUtil.dateTimeFormatter.Year;
         }
 
         public static double SecondsPerMonth()


### PR DESCRIPTION
For better compatibility with planet packs and rescales that may have non-standard calendars, read day and year length from the dateTimeFormatter.