### PR TITLE
Fix Localization bug

### DIFF
--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -649,7 +649,7 @@ namespace LifeSupport
                     return; // No need to print
                 case 1: //Grouchy
                     msg = string.Format("{0} refuses to work {1}", crew.name, reason);
-                    kStat.OldTrait = crew.experienceTrait.Title;
+                    kStat.OldTrait = crew.ExperienceTrait.TypeName;
                     crew.type = ProtoCrewMember.KerbalType.Tourist;
                     KerbalRoster.SetExperienceTrait(crew, "Tourist");
                     kStat.IsGrouchy = true;
@@ -658,7 +658,7 @@ namespace LifeSupport
                 case 2:  //Mutinous
                     {
                         msg = string.Format("{0} has become mutinous due to {1}", crew.name, reason);
-                        kStat.OldTrait = crew.experienceTrait.Title;
+                        kStat.OldTrait = crew.ExperienceTrait.TypeName;
                         crew.type = ProtoCrewMember.KerbalType.Tourist;
                         KerbalRoster.SetExperienceTrait(crew, "Tourist");
                         kStat.IsGrouchy = true;
@@ -779,7 +779,7 @@ namespace LifeSupport
                 if (crew.type != ProtoCrewMember.KerbalType.Tourist)
                 {
                     msg = string.Format("{0} refuses to work", crew.name);
-                    kStat.OldTrait = crew.experienceTrait.Title;
+                    kStat.OldTrait = crew.ExperienceTrait.TypeName;
                     crew.type = ProtoCrewMember.KerbalType.Tourist;
                     KerbalRoster.SetExperienceTrait(crew, "Tourist");
                     kStat.IsGrouchy = true;
@@ -789,7 +789,7 @@ namespace LifeSupport
                 case 2:  //Mutinous
             {
                 msg = string.Format("{0} has become mutinous", crew.name);
-                kStat.OldTrait = crew.experienceTrait.Title;
+                kStat.OldTrait = crew.ExperienceTrait.TypeName;
                 crew.type = ProtoCrewMember.KerbalType.Tourist;
                 KerbalRoster.SetExperienceTrait(crew, "Tourist");
                 kStat.IsGrouchy = true;


### PR DESCRIPTION
There is a bug if playing KSP localized, where the save file gets corrupted when a Kerbal who was changed to Tourist after depleting supplies gets recovered and his trait should change back to his old trait.

But because USI-LS saves `experienceTrait.Title` (which is localized) and not `ExperienceTrait.TypeName` (which shouldn't be localized. But I'm not  entirely sure, this needs at least testing!), it will set the localized trait title which corrupts the save file.

Fixes #259