### PR TITLE
Replace localized pcm.experienceTrait.*

### DIFF
--- a/Source/USILifeSupport/Converters/USILS_LifeSupportExtenderConverterAddon.cs
+++ b/Source/USILifeSupport/Converters/USILS_LifeSupportExtenderConverterAddon.cs
@@ -47,7 +47,7 @@ namespace LifeSupport
             for (int i = 0; i < count; ++i)
             {
                 var c = crew[i];
-                if (string.IsNullOrEmpty(RestrictedToClass) || c.experienceTrait.Title == RestrictedToClass)
+                if (string.IsNullOrEmpty(RestrictedToClass) || c.experienceTrait.Config.Name == RestrictedToClass)
                     kerbals.Add(c);
             }
 

--- a/Source/USILifeSupport/LifeSupportManager.cs
+++ b/Source/USILifeSupport/LifeSupportManager.cs
@@ -118,7 +118,7 @@ namespace LifeSupport
                 k.PreviousVesselId = "??UNKNOWN??";
                 k.LastUpdate = Planetarium.GetUniversalTime();
                 k.IsGrouchy = false;
-                k.OldTrait = crew.experienceTrait.Title;
+                k.OldTrait = crew.experienceTrait.Config.Name;
                 TrackKerbal(k);
             }
 

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -325,7 +325,7 @@ namespace LifeSupport
                                     LifeSupportManager.GetNoHomeEffect(trackedKerbal.KerbalName),
                                     "homesickness");
                             }
-                            else if (crewMember.experienceTrait.Title != trackedKerbal.OldTrait && !isAnyGrouch)
+                            else if (crewMember.experienceTrait.Config.Name != trackedKerbal.OldTrait && !isAnyGrouch)
                             {
                                 RemoveGrouchiness(crewMember, trackedKerbal);
                             }
@@ -389,7 +389,7 @@ namespace LifeSupport
 
         private void ApplyEVAEffect(LifeSupportStatus trackedKerbal, ProtoCrewMember crewMember, Vessel vessel, int effectId)
         {
-            if (crewMember.type == ProtoCrewMember.KerbalType.Tourist || crewMember.experienceTrait.Title == "Tourist")
+            if (crewMember.type == ProtoCrewMember.KerbalType.Tourist || crewMember.experienceTrait.Config.Name == "Tourist")
                 return;
 
             /* SIDE EFFECTS:
@@ -410,7 +410,7 @@ namespace LifeSupport
                     if (crewMember.type != ProtoCrewMember.KerbalType.Tourist)
                     {
                         screenMessage = string.Format("{0} refuses to work", crewMember.name);
-                        trackedKerbal.OldTrait = crewMember.experienceTrait.TypeName;
+                        trackedKerbal.OldTrait = crewMember.experienceTrait.Config.Name;
                         crewMember.type = ProtoCrewMember.KerbalType.Tourist;
                         KerbalRoster.SetExperienceTrait(crewMember, "Tourist");
                         trackedKerbal.IsGrouchy = true;
@@ -420,7 +420,7 @@ namespace LifeSupport
                 case 2:  //Mutinous
                     {
                         screenMessage = string.Format("{0} has become mutinous", crewMember.name);
-                        trackedKerbal.OldTrait = crewMember.experienceTrait.TypeName;
+                        trackedKerbal.OldTrait = crewMember.experienceTrait.Config.Name;
                         crewMember.type = ProtoCrewMember.KerbalType.Tourist;
                         KerbalRoster.SetExperienceTrait(crewMember, "Tourist");
                         trackedKerbal.IsGrouchy = true;
@@ -767,7 +767,7 @@ namespace LifeSupport
         private void ApplyEffect(LifeSupportStatus trackedKerbal, ProtoCrewMember crewMember, int effectId, string reason)
         {
             //Tourists are immune to effects
-            if (crewMember.type == ProtoCrewMember.KerbalType.Tourist || crewMember.experienceTrait.Title == "Tourist")
+            if (crewMember.type == ProtoCrewMember.KerbalType.Tourist || crewMember.experienceTrait.Config.Name == "Tourist")
                 return;
 
             /* SIDE EFFECTS:
@@ -786,7 +786,7 @@ namespace LifeSupport
                     return; // No need to print
                 case 1: //Grouchy
                     msg = string.Format("{0} refuses to work {1}", crewMember.name, reason);
-                    trackedKerbal.OldTrait = crewMember.experienceTrait.TypeName;
+                    trackedKerbal.OldTrait = crewMember.experienceTrait.Config.Name;
                     crewMember.type = ProtoCrewMember.KerbalType.Tourist;
                     KerbalRoster.SetExperienceTrait(crewMember, "Tourist");
                     trackedKerbal.IsGrouchy = true;
@@ -794,7 +794,7 @@ namespace LifeSupport
                     break;
                 case 2:  //Mutinous
                     msg = string.Format("{0} has become mutinous due to {1}", crewMember.name, reason);
-                    trackedKerbal.OldTrait = crewMember.experienceTrait.TypeName;
+                    trackedKerbal.OldTrait = crewMember.experienceTrait.Config.Name;
                     crewMember.type = ProtoCrewMember.KerbalType.Tourist;
                     KerbalRoster.SetExperienceTrait(crewMember, "Tourist");
                     trackedKerbal.IsGrouchy = true;


### PR DESCRIPTION
Fixes #259 for real this time.
#280 was an attempt but unfortunately does not work due to what seems to be a bug on SQUAD's end.

[This page](https://github.com/cake-pie/CommunityTraitIcons/wiki/Obtaining-a-Kerbal's-specialization-class-type-(ExperienceTrait-name)) details how both `ExperienceTrait.TypeName` and `ExperienceTrait.Title` are localized strings, even though the API docs seem to suggest that the former is an internal identifier and the latter is a display string.

Neither should be used for logic or persistence purposes. Use `ExperienceTrait.Config.Name` instead.