### PR TITLE
Minipak items to be enabled for stock cargo inventory system

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_01.cfg
@@ -34,6 +34,12 @@ PART
 	{
 		name = USI_ModuleResourceWarehouse
 	}
+	MODULE
+	{
+		name = ModuleCargoPart
+		stackableQuantity = 1
+		packedVolume = 100
+	}
 	RESOURCE
 	{
 		name = Supplies

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_02.cfg
@@ -34,6 +34,12 @@ PART
 	{
 		name = USI_ModuleResourceWarehouse
 	}
+	MODULE
+	{
+		name = ModuleCargoPart
+		stackableQuantity = 1
+		packedVolume = 100
+	}
 	RESOURCE
 	{
 		name = Fertilizer

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_03.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_03.cfg
@@ -34,6 +34,12 @@ PART
 	{
 		name = USI_ModuleResourceWarehouse
 	}
+	MODULE
+	{
+		name = ModuleCargoPart
+		stackableQuantity = 1
+		packedVolume = 100
+	}
 	RESOURCE
 	{
 		name = Mulch


### PR DESCRIPTION
With these stock cargo configuration changes the stock inventory system can utilize these three parts as items to deliver supplies, fertilizer and munch for other vessels without docking and resource transfer. Note that, while a single item is too heavy and big for a single kerbal engineer to carry (example on Kerbin) it can be manipulated in space or with help of other Kerbals. The stackability of one and the volume is approximation of size based on stock item Mystery Goo (75 litres, stack of one).