### PR TITLE
Fixed issue where empty parts had no cost

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Fert_125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Fert_125.cfg
@@ -17,7 +17,7 @@ PART
 
 	TechRequired = survivability
 	entryCost = 3000
-	cost = 500
+	cost = 1500
 	category = none
 	subcategory = 0
 	title = Fertilizer Tank (1.25)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Fert_250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Fert_250.cfg
@@ -17,7 +17,7 @@ PART
 
 	TechRequired = survivability
 	entryCost = 3000
-	cost = 1000
+	cost = 10000
 	category = none
 	subcategory = 0
 	title = Fertilizer Tank (2.5)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Fert_375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Fert_375.cfg
@@ -16,7 +16,7 @@ PART
 
 	TechRequired = survivability
 	entryCost = 3000
-	cost = 1500
+	cost = 31500
 	category = none
 	subcategory = 0
 	title = Fertilizer Tank (3.75)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_01.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_01.cfg
@@ -7,7 +7,7 @@ PART
 	node_attach = 0,0,.15,0,0,-1
 	TechRequired = survivability
 	entryCost = 1000
-	cost = 100
+	cost = 350
 	category = none
 	subcategory = 0
 	title = Life Support MiniPak (Supplies)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_02.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/MiniPak_02.cfg
@@ -7,7 +7,7 @@ PART
 	node_attach = 0,0,.15,0,0,-1
 	TechRequired = survivability
 	entryCost = 1000
-	cost = 100
+	cost = 300
 	category = none
 	subcategory = 0
 	title = Life Support MiniPak (Fertilizer)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_125.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_125.cfg
@@ -18,7 +18,7 @@ PART
 	tags = cck-lifesupport
 	TechRequired = survivability
 	entryCost = 3000
-	cost = 500
+	cost = 1750
 	category = none
 	subcategory = 0
 	title = Life Support Tank (1.25)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_250.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_250.cfg
@@ -18,7 +18,7 @@ PART
 	tags = cck-lifesupport
 	TechRequired = survivability
 	entryCost = 3000
-	cost = 1000
+	cost = 12250
 	category = none
 	subcategory = 0
 	title = Life Support Tank (2.5)

--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_375.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Parts/Tank_375.cfg
@@ -16,7 +16,7 @@ PART
 
 	TechRequired = survivability
 	entryCost = 3000
-	cost = 1500
+	cost = 39000
 	category = none
 	subcategory = 0
 	title = Life Support Tank (3.75)


### PR DESCRIPTION
Empty container part costs for fertilizer and supplies were not taken into account with several parts. While the Mulch had container cost as 100 for minipack,  the fertilizer and supplies costs were only subject to the resource's cost multiplied by resource units in the container, and the actual container didn't cost anything if the resource amount was set to zero at construction.

The costs have been changed to reflect the total cost of resources with a cost for the empty container.

- Empty minipack cost is 100.
- Tank sizes for 125, 250, and 375 have empty costs of 500, 1000, and 1500.
- The unit costs used for calculation were 2.5 for supplies, 2.0 for fertilizer, and 0.0 for mulch as outlined in the CommunityResourcePack/CommonResources.cfg file 

With this change one can consider returning empty containers back to the Kerbin for refurbishment.
