### PR TITLE
Update version file URLs to current repo owner

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/USI-LS.version
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/USI-LS.version
@@ -1,9 +1,9 @@
 {
      "NAME":"USI-LS",
-     "URL":"https://raw.githubusercontent.com/BobPalmer/USI-LS/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/USI-LS.version",
-     "DOWNLOAD":"https://github.com/BobPalmer/USI-LS/releases",
+     "URL":"https://raw.githubusercontent.com/UmbraSpaceIndustries/USI-LS/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/USI-LS.version",
+     "DOWNLOAD":"https://github.com/UmbraSpaceIndustries/USI-LS/releases",
      "GITHUB":{
-         "USERNAME":"BobPalmer",
+         "USERNAME":"UmbraSpaceIndustries",
          "REPOSITORY":"USI-LS",
          "ALLOW_PRE_RELEASE":false
      },


### PR DESCRIPTION
Hi @BobPalmer,

The URLs in this mod's version file are slightly out of date, they still have the previous repo owner. GitHub helpfully silently redirects them, so they still work, but this can sometimes trrigger GitHub's server-side rate limiting behavior.

Now they're updated to the latest correct values.