### PR TITLE
Improve Healing of Kerbals when their hab and home timers are expired

### DIFF
--- a/Source/USILifeSupport/Converters/USILS_LifeSupportExtenderConverterAddon.cs
+++ b/Source/USILifeSupport/Converters/USILS_LifeSupportExtenderConverterAddon.cs
@@ -38,17 +38,26 @@ namespace LifeSupport
 
             base.PostProcess(result, deltaTime);
             var baseTime = TimeMultiplier * result.TimeFactor;
-            var kerbals = new List<ProtoCrewMember>();
+            var kerbals = new List<LifeSupportStatus>();
             var crew = Converter.vessel.GetVesselCrew();
             if (AffectsPartOnly)
                 crew = Converter.part.protoModuleCrew;
 
+            var moduleLifeSupportSystem = Converter.vessel.FindVesselModuleImplementing<ModuleLifeSupportSystem>();
+            var habTime = -1.0d;
+            if (moduleLifeSupportSystem != null)
+                habTime = LifeSupportManager.GetTotalHabTime(moduleLifeSupportSystem.VesselStatus, Converter.vessel);
+
+            var now = Planetarium.GetUniversalTime();
             var count = crew.Count;
             for (int i = 0; i < count; ++i)
             {
                 var c = crew[i];
-                if (string.IsNullOrEmpty(RestrictedToClass) || c.experienceTrait.Config.Name == RestrictedToClass)
-                    kerbals.Add(c);
+                var lsKerbal = LifeSupportManager.Instance.FetchKerbal(c);
+
+                // Kerbals get healed either when they are tourists or when their LastAtHome or TimeEnteredVessel lie in the past
+                if (string.IsNullOrEmpty(RestrictedToClass) || c.experienceTrait.Config.Name == RestrictedToClass || lsKerbal.LastAtHome < now || lsKerbal.TimeEnteredVessel < now)
+                    kerbals.Add(lsKerbal);
             }
 
             if (kerbals.Count == 0)
@@ -59,12 +68,35 @@ namespace LifeSupport
             count = kerbals.Count;
             for (int i = 0; i < count; ++i)
             {
-                var k = kerbals[i];
-                var lsKerbal = LifeSupportManager.Instance.FetchKerbal(k);
+                var lsKerbal = kerbals[i];
                 if (AffectsHomeTimer)
-                    lsKerbal.MaxOffKerbinTime += timePerKerbal;
+                {
+                    // Calculate time adjustment value
+                    var delta = timePerKerbal;
+                    if (now - lsKerbal.LastAtHome > 0 && now - lsKerbal.LastAtHome < delta)
+                        delta = now - lsKerbal.LastAtHome;
+
+                    // Adjust both values, that are responsible for the home timer and keep their interval (TotalHabTime of vessel) the same
+                    lsKerbal.MaxOffKerbinTime += delta;
+                    lsKerbal.LastAtHome += delta;
+                    
+                    // make sure that LastAtHome is not in the future
+                    if (lsKerbal.LastAtHome > now)
+                    {
+                        lsKerbal.MaxOffKerbinTime -= lsKerbal.LastAtHome - now;
+                        lsKerbal.LastAtHome = now;
+                    }
+
+                    // make sure that MaxOffKerbinTime is not too far in the future, but adjusted to the habTime of the current vessel
+                    if (habTime > 0.0f && now + habTime < lsKerbal.MaxOffKerbinTime)
+                        lsKerbal.MaxOffKerbinTime = now + habTime;
+                }
                 if (AffectsHabTimer)
+                {
                     lsKerbal.TimeEnteredVessel += timePerKerbal;
+                    if (lsKerbal.TimeEnteredVessel > now)
+                        lsKerbal.TimeEnteredVessel = now;
+                }
 
                 LifeSupportManager.Instance.TrackKerbal(lsKerbal);
             }

--- a/Source/USILifeSupport/LifeSupportMonitor.cs
+++ b/Source/USILifeSupport/LifeSupportMonitor.cs
@@ -435,7 +435,7 @@ namespace LifeSupport
                 else if (habTimeLeft < 0)
                 {
                     lblHab = "FF5E5E";
-                    crewHabString = "expired";
+                    crewHabString = "expired (" + LifeSupportUtilities.SmartDurationDisplay(-habTimeLeft) + ")";
                 }
                 else
                 {
@@ -474,7 +474,7 @@ namespace LifeSupport
                 else if (homeTimeLeft < 0)
                 {
                     lblHome = "FF5E5E";
-                    crewHomeString = "expired";
+                    crewHomeString = "expired (" + LifeSupportUtilities.SmartDurationDisplay(-homeTimeLeft) + ")";
                 }
                 else
                 {


### PR DESCRIPTION
- In addition to healing tourists, Kerbals now also get healed (in the meaning that their hab and home timers increase) when their LastAtHome or TimeEnteredVessel lie in the past (fix #314)
- For adjusting the home-timer, additionally LastAtHome gets adjusted (to keep the difference between MaxOffKerbinTime and LastAtHome always the same at TotalHabTime of the vessel)
- Show the overtime for expired hab and home timers in LifeSupportMonitor, which helps with estimating the time needed for healing them (QoL improvement)