### PR TITLE
Experimental hab-cabin time implementation

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Settings.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/LifeSupport/Settings.cfg
@@ -20,6 +20,7 @@ LIFE_SUPPORT_SETTINGS
 	BaseHabTime = 0.25	//How long can 1 crew capacity support 1 Kerbal, expressed in Kerbal Months
 	ReplacementPartAmount = 0	//How fast life support equipment and habs 'wears out'
 	HabRange = 150				//How close we need to be to use other vessel's habitation modules and recyclers.
+	RecoverySpeed = 1           //Rate at which Kerbals recover cabin time while in a habitat (seconds per second)
 	EnableRecyclers = true		//Use resource recyclers?  Not the same as resource converteres like greenhouses!
 	VetNames = Jebediah,Valentina,Bill,Bob	
 	ScoutHabTime = 9180000

--- a/Source/USILifeSupport/Converters/USILS_HabitationSwapOption.cs
+++ b/Source/USILifeSupport/Converters/USILS_HabitationSwapOption.cs
@@ -33,7 +33,7 @@ namespace LifeSupport
             var output = new StringBuilder();
             output.AppendLine();
             output.AppendLine(base.GetInfo());
-            output.AppendLine(string.Format("Kerbal-Months: {0}", BaseKerbalMonths + part.CrewCapacity));
+            output.AppendLine(string.Format("Kerbal-Months: {0}", BaseKerbalMonths));
             output.AppendLine(string.Format("Crew Affected: {0}", CrewCapacity));
             output.AppendLine(string.Format("Hab Multipler: {0}", BaseHabMultiplier));
 

--- a/Source/USILifeSupport/Converters/USILS_LifeSupportExtenderConverterAddon.cs
+++ b/Source/USILifeSupport/Converters/USILS_LifeSupportExtenderConverterAddon.cs
@@ -61,10 +61,11 @@ namespace LifeSupport
             {
                 var k = kerbals[i];
                 var lsKerbal = LifeSupportManager.Instance.FetchKerbal(k);
-                if (AffectsHomeTimer)
-                    lsKerbal.MaxOffKerbinTime += timePerKerbal;
-                if (AffectsHabTimer)
-                    lsKerbal.TimeEnteredVessel += timePerKerbal;
+
+                // Experimental patch.
+                // I don't like changing LastAtHome but the alternative is that we add another variable...
+                if (AffectsHomeTimer || AffectsHabTimer)
+                    lsKerbal.LastAtHome += timePerKerbal;
 
                 LifeSupportManager.Instance.TrackKerbal(lsKerbal);
             }

--- a/Source/USILifeSupport/LifeSupportConfig.cs
+++ b/Source/USILifeSupport/LifeSupportConfig.cs
@@ -23,6 +23,7 @@
         public double BaseHabTime { get; set; }
         public bool EnableRecyclers { get; set; }
         public double HabRange { get; set; }
+        public float RecoverySpeed { get; set; }
         public double ScoutHabTime { get; set; }
         public double PermaHabTime { get; set; }
     }

--- a/Source/USILifeSupport/LifeSupportManager.cs
+++ b/Source/USILifeSupport/LifeSupportManager.cs
@@ -112,10 +112,10 @@ namespace LifeSupport
                 k.LastEC = Planetarium.GetUniversalTime();
                 k.LastAtHome = Planetarium.GetUniversalTime();
                 k.LastSOIChange = Planetarium.GetUniversalTime();
-                k.MaxOffKerbinTime = Planetarium.GetUniversalTime() + 648000;    
-                k.TimeEnteredVessel = Planetarium.GetUniversalTime();
                 k.CurrentVesselId = "?UNKNOWN?";
                 k.PreviousVesselId = "??UNKNOWN??";
+                k.RemainingCabinTime = LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime 
+                    * LifeSupportUtilities.SecondsPerMonth();
                 k.LastUpdate = Planetarium.GetUniversalTime();
                 k.IsGrouchy = false;
                 k.OldTrait = crew.experienceTrait.Config.Name;
@@ -391,7 +391,6 @@ namespace LifeSupport
 
             double totHabSpace = sourceVessel.ExtraHabSpace;
             double totHabMult = CalculateVesselHabMultiplier(vsl, 1);
-            totHabSpace += (LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime * totMaxCrew);
 
             var hCount = hList.Count;
             for (int i = 0; i < hCount; ++i)
@@ -439,7 +438,6 @@ namespace LifeSupport
             }
             double totHabSpace = sourceVessel.ExtraHabSpace;
             double totHabMult = CalculateVesselHabMultiplier(vessel,totCurCrew);
-            totHabSpace += (LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime * totMaxCrew);
 
             var hCount = hList.Count;
             for (int i = 0; i < hCount; ++i)

--- a/Source/USILifeSupport/LifeSupportMonitor.cs
+++ b/Source/USILifeSupport/LifeSupportMonitor.cs
@@ -109,16 +109,37 @@ namespace LifeSupport
             vstat.LastUpdate = kerbal.missionTime;
             var sitString = "(EVA)";
 
+            var evaKerbal = kerbal.GetVesselCrew()[0];
+            var kerbalStatus = LifeSupportManager.Instance.FetchKerbal(evaKerbal);
+            var cabinTime = kerbalStatus.RemainingCabinTime;
+            var cabinTimeString = LifeSupportUtilities.SmartDurationDisplay(Math.Max(0, cabinTime));
+
             var remEVATime = LifeSupportScenario.Instance.settings.GetSettings().EVATime - kerbal.missionTime;
             var timeString = LifeSupportUtilities.SmartDurationDisplay(Math.Max(0, remEVATime));
+
+            var secondsPerDay = LifeSupportUtilities.SecondsPerDay();
+            
+
+            var lblCabin = "6FFF00";
+            if (cabinTime < secondsPerDay * 3)
+            {
+                lblCabin = "FFE100";
+            }
+            if (cabinTime < secondsPerDay * 1)
+            {
+                lblCabin = "FFAE00";
+            }
 
             if (remEVATime > 0)
             {
                 vstat.SummaryLabel = String.Format(
-                    "<color=#3DB1FF>{0}/{1} - </color><color=#9EE4FF>{2}</color><color=#3DB1FF> time remaining</color>"
+                    "<color=#3DB1FF>{0}/{1} - </color><color=#9EE4FF>{2}</color><color=#3DB1FF> time remaining   -   </color>" +
+                    "<color=#{3}>{4}</color><color=#3DB1FF> cabin time</color>"
                     , kerbal.mainBody.bodyName
                     , sitString
-                    , timeString);
+                    , timeString
+                    , lblCabin
+                    , cabinTimeString);
             }
             else
             {
@@ -485,11 +506,11 @@ namespace LifeSupport
 
                     crewCabinString = LifeSupportUtilities.SmartDurationDisplay(adjustedCabinTimeLeft);
                     var secondsPerDay = LifeSupportUtilities.SecondsPerDay();
-                    if (adjustedCabinTimeLeft < secondsPerDay * 30)
+                    if (adjustedCabinTimeLeft < secondsPerDay * 3)
                     {
                         lblCabin = "FFE100";
                     }
-                    if (adjustedCabinTimeLeft < secondsPerDay * 15)
+                    if (adjustedCabinTimeLeft < secondsPerDay * 1)
                     {
                         lblCabin = "FFAE00";
                     }

--- a/Source/USILifeSupport/LifeSupportMonitor_Editor.cs
+++ b/Source/USILifeSupport/LifeSupportMonitor_Editor.cs
@@ -252,12 +252,14 @@ namespace LifeSupport
                     cabin_curCrew = LifeSupportUtilities.DurationDisplay(
                         LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime *
                         LifeSupportUtilities.SecondsPerMonth() *
-                        ((double)maxCrew / (double)Math.Max(1, curCrew))
+                        ((double)maxCrew / (double)Math.Max(1, curCrew)) *
+                        habMult
                     );
                     cabin_maxCrew = LifeSupportUtilities.DurationDisplay(
                         LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime *
                         LifeSupportUtilities.SecondsPerMonth() *
-                        ((double)maxCrew / (double)Math.Max(1, maxCrew))
+                        ((double)maxCrew / (double)Math.Max(1, maxCrew)) *
+                        habMult
                     );
 
                     supplyExt_curCrew = LifeSupportUtilities.DurationDisplay(

--- a/Source/USILifeSupport/LifeSupportMonitor_Editor.cs
+++ b/Source/USILifeSupport/LifeSupportMonitor_Editor.cs
@@ -127,6 +127,8 @@ namespace LifeSupport
         private string hab_maxCrew = "";
         private string supply_curCrew = "";
         private string supply_maxCrew = "";
+        private string cabin_curCrew = "";
+        private string cabin_maxCrew = "";
 
         private string habExt_curCrew = "";
         private string habExt_maxCrew = "";
@@ -203,7 +205,7 @@ namespace LifeSupport
                     }
                 }
 
-                totalHabSpace = (LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime * maxCrew) + extraHabTime;
+                totalHabSpace = extraHabTime;
                 //A Kerbal month is 30 six-hour Kerbin days.
                 totalHabMult = habMult * LifeSupportScenario.Instance.settings.GetSettings().HabMultiplier * LifeSupportUtilities.SecondsPerMonth();
                 totalBatteryTime = batteryAmount / LifeSupportScenario.Instance.settings.GetSettings().ECAmount;
@@ -246,6 +248,17 @@ namespace LifeSupport
 
                     hab_curCrew = LifeSupportUtilities.DurationDisplay(totalHabSpace / Math.Max(1, curCrew) * totalHabMult);
                     hab_maxCrew = LifeSupportUtilities.DurationDisplay(totalHabSpace / Math.Max(1, maxCrew) * totalHabMult);
+
+                    cabin_curCrew = LifeSupportUtilities.DurationDisplay(
+                        LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime *
+                        LifeSupportUtilities.SecondsPerMonth() *
+                        ((double)maxCrew / (double)Math.Max(1, curCrew))
+                    );
+                    cabin_maxCrew = LifeSupportUtilities.DurationDisplay(
+                        LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime *
+                        LifeSupportUtilities.SecondsPerMonth() *
+                        ((double)maxCrew / (double)Math.Max(1, maxCrew))
+                    );
 
                     supplyExt_curCrew = LifeSupportUtilities.DurationDisplay(
                         (totalSupplyTime + totalFertilizerTime) /
@@ -364,42 +377,39 @@ namespace LifeSupport
                     {
                         // column widths
                         const int c1 = 150;
-                        const int c2 = 80;
+                        const int c2 = 90;
                         const int c3 = 80;
-                        const int c4 = 90;
-                        const int c5 = 80;
-                        const int c6 = 50;
-                        const int c7 = 50;
+                        const int c4 = 50;
+                        const int c5 = 50;
+                        const int c6 = 120;
 
                         GUILayout.BeginHorizontal();
                         GUILayout.Label("Habitation", _labelStyle, GUILayout.Width(c1 - 30));
-                        GUILayout.Label(CTag("= ( (", operColor), _labelStyle, GUILayout.Width(30));
-                        GUILayout.Label("BaseTime " + CTag("*", operColor), _labelStyle, GUILayout.Width(c2));
-                        GUILayout.Label("MaxCrew " + CTag(") +", operColor), _labelStyle, GUILayout.Width(c3));
-                        GUILayout.Label("ExtraTime " + CTag(") *", operColor), _labelStyle, GUILayout.Width(c4));
-                        GUILayout.Label("Multiplier " + CTag("/", operColor), _labelStyle, GUILayout.Width(c5));
-                        GUILayout.Label("Crew " + CTag("*", operColor), _labelStyle, GUILayout.Width(c6));
-                        GUILayout.Label("Months", _labelStyle, GUILayout.Width(c7));
+                        GUILayout.Label(CTag(" = ", operColor), _labelStyle, GUILayout.Width(30));
+                        GUILayout.Label("ExtraTime " + CTag("*", operColor), _labelStyle, GUILayout.Width(c2));
+                        GUILayout.Label("Multiplier " + CTag("/", operColor), _labelStyle, GUILayout.Width(c3));
+                        GUILayout.Label("Crew " + CTag("*", operColor), _labelStyle, GUILayout.Width(c4));
+                        GUILayout.Label("Months", _labelStyle, GUILayout.Width(c5));
+                        GUILayout.Label("+CabinTime", _labelStyle, GUILayout.Width(c6));
+
                         GUILayout.EndHorizontal();
 
                         GUILayout.BeginHorizontal();
                         GUILayout.Label(CTag(hab_curCrew, textColor), _labelStyle, GUILayout.Width(c1));
-                        GUILayout.Label(CTag(LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime.ToString(), fadeColor), _labelStyle, GUILayout.Width(c2));
-                        GUILayout.Label(CTag(maxCrew.ToString(), crewColor), _labelStyle, GUILayout.Width(c3));
-                        GUILayout.Label(CTag(extraHabTime.ToString(), textColor), _labelStyle, GUILayout.Width(c4));
-                        GUILayout.Label(CTag("(1+" + (habMult-1d) +")", textColor), _labelStyle, GUILayout.Width(c5));
-                        GUILayout.Label(CTag(Math.Max(1, curCrew).ToString(), crewColor), _labelStyle, GUILayout.Width(c6));
-                        GUILayout.Label(CTag(LifeSupportScenario.Instance.settings.GetSettings().HabMultiplier.ToString(), fadeColor), _labelStyle, GUILayout.Width(c7));
+                        GUILayout.Label(CTag(extraHabTime.ToString(), textColor), _labelStyle, GUILayout.Width(c2));
+                        GUILayout.Label(CTag("(1+" + (habMult-1d) +")", textColor), _labelStyle, GUILayout.Width(c3));
+                        GUILayout.Label(CTag(Math.Max(1, curCrew).ToString(), crewColor), _labelStyle, GUILayout.Width(c4));
+                        GUILayout.Label(CTag(LifeSupportScenario.Instance.settings.GetSettings().HabMultiplier.ToString(), fadeColor), _labelStyle, GUILayout.Width(c5));
+                        GUILayout.Label(CTag(cabin_curCrew, textColor), _labelStyle, GUILayout.Width(c6));
                         GUILayout.EndHorizontal();
 
                         GUILayout.BeginHorizontal();
                         GUILayout.Label(CTag(hab_maxCrew, textColor), _labelStyle, GUILayout.Width(c1));
-                        GUILayout.Label(CTag(LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime.ToString(), fadeColor), _labelStyle, GUILayout.Width(c2));
-                        GUILayout.Label(CTag(maxCrew.ToString(), crewColor), _labelStyle, GUILayout.Width(c3));
-                        GUILayout.Label(CTag(extraHabTime.ToString(), textColor), _labelStyle, GUILayout.Width(c4));
-                        GUILayout.Label(CTag("(1+" + (habMult - 1d) + ")", textColor), _labelStyle, GUILayout.Width(c5));
-                        GUILayout.Label(CTag(Math.Max(1, maxCrew).ToString(), crewColor), _labelStyle, GUILayout.Width(c6));
-                        GUILayout.Label(CTag(LifeSupportScenario.Instance.settings.GetSettings().HabMultiplier.ToString(), fadeColor), _labelStyle, GUILayout.Width(c7));
+                        GUILayout.Label(CTag(extraHabTime.ToString(), textColor), _labelStyle, GUILayout.Width(c2));
+                        GUILayout.Label(CTag("(1+" + (habMult - 1d) + ")", textColor), _labelStyle, GUILayout.Width(c3));
+                        GUILayout.Label(CTag(Math.Max(1, maxCrew).ToString(), crewColor), _labelStyle, GUILayout.Width(c4));
+                        GUILayout.Label(CTag(LifeSupportScenario.Instance.settings.GetSettings().HabMultiplier.ToString(), fadeColor), _labelStyle, GUILayout.Width(c5));
+                        GUILayout.Label(CTag(cabin_maxCrew, textColor), _labelStyle, GUILayout.Width(c6));
                         GUILayout.EndHorizontal();
                     }
 

--- a/Source/USILifeSupport/LifeSupportMonitor_SpaceCenter.cs
+++ b/Source/USILifeSupport/LifeSupportMonitor_SpaceCenter.cs
@@ -11,7 +11,7 @@ namespace LifeSupport
     public class LifeSupportMonitor_SpaceCenter : MonoBehaviour
     {
         private ApplicationLauncherButton orbLogButton;
-        private Rect _windowPosition = new Rect(300, 60, 500, 550);
+        private Rect _windowPosition = new Rect(300, 60, 500, 560);
         private GUIStyle _windowStyle;
         private GUIStyle _labelStyle;
         private GUIStyle _smButtonStyle;
@@ -62,6 +62,7 @@ namespace LifeSupport
             habRange = config.HabRange.ToString();
             homeAltitude = config.HomeWorldAltitude.ToString();
             baseHabTime = config.BaseHabTime.ToString();
+            recoverySpeed = config.RecoverySpeed.ToString();
             vetNames = config.VetNames;
         }
 
@@ -123,6 +124,7 @@ namespace LifeSupport
         private string habRange;
         private string homeAltitude;
         private string baseHabTime;
+        private string recoverySpeed;
         private string vetNames;
 
         private void GenerateWindow()
@@ -220,11 +222,16 @@ namespace LifeSupport
                 GUILayout.Label("Hab Multiplier:", _labelStyle, GUILayout.Width(c1));
                 habMulti = GUILayout.TextField(habMulti, 3, GUILayout.Width(c4));
                 GUILayout.Label("", _labelStyle, GUILayout.Width(c6));
-                GUILayout.Label("Hab Months:", _labelStyle, GUILayout.Width(80));
+                GUILayout.Label("Cabin Months:", _labelStyle, GUILayout.Width(90));
                 baseHabTime = GUILayout.TextField(baseHabTime, 10, GUILayout.Width(c4));
                 GUILayout.Label("", _labelStyle, GUILayout.Width(c6));
                 GUILayout.Label("Hab Range:", _labelStyle, GUILayout.Width(c7));
                 habRange = GUILayout.TextField(habRange, 4, GUILayout.Width(c4));
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                GUILayout.Label("Recovery Speed:", _labelStyle, GUILayout.Width(c1));
+                recoverySpeed = GUILayout.TextField(recoverySpeed, 4, GUILayout.Width(c4));
                 GUILayout.EndHorizontal();
 
                 GUILayout.BeginHorizontal();
@@ -286,6 +293,7 @@ namespace LifeSupport
             config.HabRange = SaveDouble(config.HabRange,habRange);
             config.HomeWorldAltitude = SaveInt(config.HomeWorldAltitude,homeAltitude);
             config.BaseHabTime = SaveDouble(config.BaseHabTime,baseHabTime);
+            config.RecoverySpeed = SaveFloat(config.RecoverySpeed,recoverySpeed);
             config.VetNames = vetNames;
             LifeSupportScenario.Instance.settings.SaveConfig(config);
             GuiOff();

--- a/Source/USILifeSupport/LifeSupportPersistance.cs
+++ b/Source/USILifeSupport/LifeSupportPersistance.cs
@@ -197,10 +197,9 @@ namespace LifeSupport
                     rNode.AddValue("LastAtHome", r.LastAtHome);
                     rNode.AddValue("LastSOIChange", r.LastSOIChange);
                     rNode.AddValue("LastPlanet", r.LastPlanet);
-                    rNode.AddValue("MaxOffKerbinTime", r.MaxOffKerbinTime);
                     rNode.AddValue("CurrentVesselId", r.CurrentVesselId);
                     rNode.AddValue("PreviousVesselId", r.PreviousVesselId);
-                    rNode.AddValue("TimeEnteredVessel", r.TimeEnteredVessel);
+                    rNode.AddValue("RemainingCabinTime", r.RemainingCabinTime);
                     rNode.AddValue("IsGrouchy", r.IsGrouchy);
                     rNode.AddValue("OldTrait", r.OldTrait);
                     rNode.AddValue("LastUpdate", r.LastUpdate);
@@ -429,10 +428,9 @@ namespace LifeSupport
             kerbInfo.LastSOIChange = status.LastSOIChange;
             kerbInfo.HomeBodyId = status.HomeBodyId;
             kerbInfo.LastPlanet = status.LastPlanet;
-            kerbInfo.MaxOffKerbinTime = status.MaxOffKerbinTime;
-            kerbInfo.TimeEnteredVessel = status.TimeEnteredVessel;
             kerbInfo.CurrentVesselId = status.CurrentVesselId;
             kerbInfo.PreviousVesselId = status.PreviousVesselId;
+            kerbInfo.RemainingCabinTime = status.RemainingCabinTime;
             kerbInfo.IsGrouchy = status.IsGrouchy;
             kerbInfo.OldTrait = status.OldTrait;
             kerbInfo.LastUpdate = status.LastUpdate;

--- a/Source/USILifeSupport/LifeSupportPersistance.cs
+++ b/Source/USILifeSupport/LifeSupportPersistance.cs
@@ -88,6 +88,7 @@ namespace LifeSupport
                 ScoutHabTime = 9180000,
                 PermaHabTime = 459000000,
                 HabRange = 2000,
+                RecoverySpeed = 1f,
                 VetNames = ""
             };
 
@@ -125,6 +126,7 @@ namespace LifeSupport
                 finalSettings.EVAEffectVets = Math.Max(settings.EVAEffectVets, finalSettings.EVAEffectVets);
                 finalSettings.VetNames += settings.VetNames + ",";
                 finalSettings.HabRange = Math.Min(settings.HabRange, finalSettings.HabRange);
+                finalSettings.RecoverySpeed = Math.Min(settings.RecoverySpeed, finalSettings.RecoverySpeed);
                 if (settings.EnableRecyclers)
                     finalSettings.EnableRecyclers = true;
             }
@@ -257,6 +259,7 @@ namespace LifeSupport
                 sNode.AddValue("ReplacementPartAmount", _Settings.ReplacementPartAmount);
                 sNode.AddValue("EnableRecyclers", _Settings.EnableRecyclers);
                 sNode.AddValue("HabRange", _Settings.HabRange);
+                sNode.AddValue("RecoverySpeed", _Settings.RecoverySpeed);
                 sNode.AddValue("VetNames", _Settings.VetNames);
                 SettingsNode.AddNode(sNode);
             }
@@ -399,6 +402,7 @@ namespace LifeSupport
             _Settings.ReplacementPartAmount = config.ReplacementPartAmount;
             _Settings.EnableRecyclers = config.EnableRecyclers;
             _Settings.HabRange = config.HabRange;
+            _Settings.RecoverySpeed = config.RecoverySpeed;
             _Settings.VetNames = config.VetNames;
         }
 

--- a/Source/USILifeSupport/LifeSupportStatus.cs
+++ b/Source/USILifeSupport/LifeSupportStatus.cs
@@ -16,5 +16,6 @@ namespace LifeSupport
         public double TimeEnteredVessel { get; set; }
         public string CurrentVesselId { get; set; }
         public string PreviousVesselId { get; set; }
+        public double RemainingCabinTime { get; set; }
     }
 }

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -248,7 +248,6 @@ namespace LifeSupport
                             if (_isStatusRefreshRequired)
                             {
                                 trackedKerbal.TimeEnteredVessel = now;
-                                _isStatusRefreshRequired = false;
                                 LifeSupportManager.Instance.TrackKerbal(trackedKerbal);
                             }
 
@@ -331,6 +330,10 @@ namespace LifeSupport
                             }
 
                             LifeSupportManager.Instance.TrackKerbal(trackedKerbal);
+                        }
+                        if (_isStatusRefreshRequired)
+                        {
+                            _isStatusRefreshRequired = false;
                         }
                     }
                     #endregion - Crew

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -289,8 +289,7 @@ namespace LifeSupport
                                 // If we ran out of hab time, any remaining time in the update consumes cabin time.
                                 if (timePermittedWithinHab < timeSinceUpdate)
                                 {
-                                    // Consume the remaining amount in cabin time, scaling by seat fraction filled.
-                                    // TODO: multiplier-based modifier?
+                                    // Consume the remaining amount in cabin time, scaling by seat fraction filled and multiplier.
                                     trackedKerbal.RemainingCabinTime -= (timeSinceUpdate - timePermittedWithinHab)
                                         * ((double)VesselStatus.NumCrew / (double)VesselStatus.CrewCap)
                                         * (1.0 / (1 + VesselStatus.VesselHabMultiplier));
@@ -412,6 +411,10 @@ namespace LifeSupport
             //Update cabin time while EVA - this won't cause any effects until they board something, which is fine for now
             var now = Planetarium.GetUniversalTime();
             kerbalStatus.RemainingCabinTime -= now - kerbalStatus.LastUpdate;
+            if (kerbalStatus.RemainingCabinTime < -2)
+            {
+                kerbalStatus.RemainingCabinTime = -2;
+            }
             kerbalStatus.LastUpdate = now;
 
             if (evaKerbal.missionTime > LifeSupportScenario.Instance.settings.GetSettings().EVATime)

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -251,6 +251,13 @@ namespace LifeSupport
                             }
 
                             // Update Hab effects
+
+                            // I guess if you've colonized a planet, Kerbals starting there should get cabin time refills?
+                            if (!offKerbin || isHomeWorld)
+                            {
+                                trackedKerbal.RemainingCabinTime = LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime
+                                    * LifeSupportUtilities.SecondsPerMonth();
+                            }
                             if (!offKerbin || isScout || isHomeWorld || isPermaHab)
                             {
                                 trackedKerbal.LastAtHome = now;

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -292,7 +292,8 @@ namespace LifeSupport
                                     // Consume the remaining amount in cabin time, scaling by seat fraction filled.
                                     // TODO: multiplier-based modifier?
                                     trackedKerbal.RemainingCabinTime -= (timeSinceUpdate - timePermittedWithinHab)
-                                        * ((double)VesselStatus.NumCrew / (double)VesselStatus.CrewCap);
+                                        * ((double)VesselStatus.NumCrew / (double)VesselStatus.CrewCap)
+                                        * (1.0 / (1 + VesselStatus.VesselHabMultiplier));
                                     // Now cap it so we don't have cabin time going crazy negative when loading a vessel after a while
                                     if (trackedKerbal.RemainingCabinTime < -2)
                                     {

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -275,7 +275,8 @@ namespace LifeSupport
                                     // Count just the remaining hab time if we don't have enough to span the full update
                                     var habTimeCountingTowardsRegen = Math.Min(timeSinceUpdate, timePermittedWithinHab);
                                     // Regenerate
-                                    trackedKerbal.RemainingCabinTime += (habTimeCountingTowardsRegen); //TODO: multiply by scaling setting?
+                                    trackedKerbal.RemainingCabinTime += (habTimeCountingTowardsRegen) * 
+                                        LifeSupportScenario.Instance.settings.GetSettings().RecoverySpeed;
                                     // Now cap it before trying to remove any
                                     if (trackedKerbal.RemainingCabinTime > LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime
                                         * LifeSupportUtilities.SecondsPerMonth())

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -274,15 +274,14 @@ namespace LifeSupport
                                 // Handle cabin time consumption or regeneration...
 
                                 var timeSinceUpdate = now - trackedKerbal.LastUpdate;
-                                var timePermittedWithinHab = Math.Max(0, VesselStatus.CachedHabTime - (now - trackedKerbal.LastAtHome));
+                                var timeSpentUnderHab = Math.Min(timeSinceUpdate,
+                                    Math.Max(0, habTime - (trackedKerbal.LastUpdate - trackedKerbal.LastAtHome)));
 
                                 // First regenerate based on the amount of hab time we had left.
-                                if (timePermittedWithinHab > 0)
+                                if (timeSpentUnderHab > 0)
                                 {
-                                    // Count just the remaining hab time if we don't have enough to span the full update
-                                    var habTimeCountingTowardsRegen = Math.Min(timeSinceUpdate, timePermittedWithinHab);
                                     // Regenerate
-                                    trackedKerbal.RemainingCabinTime += (habTimeCountingTowardsRegen) * 
+                                    trackedKerbal.RemainingCabinTime += (timeSpentUnderHab) * 
                                         LifeSupportScenario.Instance.settings.GetSettings().RecoverySpeed;
                                     // Now cap it before trying to remove any
                                     if (trackedKerbal.RemainingCabinTime > LifeSupportScenario.Instance.settings.GetSettings().BaseHabTime
@@ -294,10 +293,10 @@ namespace LifeSupport
                                 }
 
                                 // If we ran out of hab time, any remaining time in the update consumes cabin time.
-                                if (timePermittedWithinHab < timeSinceUpdate)
+                                if (timeSpentUnderHab < timeSinceUpdate)
                                 {
                                     // Consume the remaining amount in cabin time, scaling by seat fraction filled and multiplier.
-                                    trackedKerbal.RemainingCabinTime -= (timeSinceUpdate - timePermittedWithinHab)
+                                    trackedKerbal.RemainingCabinTime -= (timeSinceUpdate - timeSpentUnderHab)
                                         * ((double)VesselStatus.NumCrew / (double)VesselStatus.CrewCap)
                                         * (1.0 / (1 + VesselStatus.VesselHabMultiplier));
                                     // Now cap it so we don't have cabin time going crazy negative when loading a vessel after a while

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -420,7 +420,12 @@ namespace LifeSupport
             if (evaKerbal.missionTime > LifeSupportScenario.Instance.settings.GetSettings().EVATime)
             {
                 var effect = LifeSupportManager.GetEVAExcessEffect(kerbalStatus.KerbalName);
-                ApplyEVAEffect(kerbalStatus, kerbal, evaKerbal, effect);
+                ApplyEVAEffect(kerbalStatus, kerbal, evaKerbal, effect, "excessive EVA time");
+            }
+            else if (kerbalStatus.RemainingCabinTime < 0)
+            {
+                var effect = LifeSupportManager.GetNoHomeEffect(kerbalStatus.KerbalName);
+                ApplyEVAEffect(kerbalStatus, kerbal, evaKerbal, effect, "homesickness");
             }
         }
 
@@ -430,7 +435,7 @@ namespace LifeSupport
                     (evaKerbal.altitude < LifeSupportScenario.Instance.settings.GetSettings().HomeWorldAltitude);
         }
 
-        private void ApplyEVAEffect(LifeSupportStatus trackedKerbal, ProtoCrewMember crewMember, Vessel vessel, int effectId)
+        private void ApplyEVAEffect(LifeSupportStatus trackedKerbal, ProtoCrewMember crewMember, Vessel vessel, int effectId, string reason)
         {
             if (crewMember.type == ProtoCrewMember.KerbalType.Tourist || crewMember.experienceTrait.Config.Name == "Tourist")
                 return;
@@ -452,7 +457,7 @@ namespace LifeSupport
                 case 1: //Grouchy
                     if (crewMember.type != ProtoCrewMember.KerbalType.Tourist)
                     {
-                        screenMessage = string.Format("{0} refuses to work", crewMember.name);
+                        screenMessage = string.Format("{0} refuses to work due to {1}", crewMember.name, reason);
                         trackedKerbal.OldTrait = crewMember.experienceTrait.Config.Name;
                         crewMember.type = ProtoCrewMember.KerbalType.Tourist;
                         KerbalRoster.SetExperienceTrait(crewMember, "Tourist");
@@ -462,7 +467,7 @@ namespace LifeSupport
                     break;
                 case 2:  //Mutinous
                     {
-                        screenMessage = string.Format("{0} has become mutinous", crewMember.name);
+                        screenMessage = string.Format("{0} has become mutinous due to {1}", crewMember.name, reason);
                         trackedKerbal.OldTrait = crewMember.experienceTrait.Config.Name;
                         crewMember.type = ProtoCrewMember.KerbalType.Tourist;
                         KerbalRoster.SetExperienceTrait(crewMember, "Tourist");
@@ -472,19 +477,19 @@ namespace LifeSupport
                     }
                     break;
                 case 3: //Return to KSC
-                    screenMessage = string.Format("{0} gets fed up and wanders back to the KSC", crewMember.name);
+                    screenMessage = string.Format("{0} gets fed up and wanders back to the KSC due to {1}", crewMember.name, reason);
                     LifeSupportManager.Instance.UntrackKerbal(crewMember.name);
                     crewMember.rosterStatus = ProtoCrewMember.RosterStatus.Available;
                     DestroyVessel(vessel);
                     break;
                 case 4: //Despawn
-                    screenMessage = string.Format("{0} has gone missing", crewMember.name);
+                    screenMessage = string.Format("{0} has gone missing due to {1}", crewMember.name, reason);
                     LifeSupportManager.Instance.UntrackKerbal(crewMember.name);
                     crewMember.rosterStatus = ProtoCrewMember.RosterStatus.Missing;
                     DestroyVessel(vessel);
                     break;
                 case 5: //Kill
-                    screenMessage = string.Format("{0} has died", crewMember.name);
+                    screenMessage = string.Format("{0} has died due to {1}", crewMember.name, reason);
                     LifeSupportManager.Instance.UntrackKerbal(crewMember.name);
                     crewMember.rosterStatus = ProtoCrewMember.RosterStatus.Dead;
                     DestroyVessel(vessel);

--- a/Source/USILifeSupport/ModuleLifeSupportSystem.cs
+++ b/Source/USILifeSupport/ModuleLifeSupportSystem.cs
@@ -473,26 +473,25 @@ namespace LifeSupport
                         KerbalRoster.SetExperienceTrait(crewMember, "Tourist");
                         trackedKerbal.IsGrouchy = true;
                         LifeSupportManager.Instance.TrackKerbal(trackedKerbal);
-                        DestroyRandomPart(vessel);
                     }
                     break;
                 case 3: //Return to KSC
                     screenMessage = string.Format("{0} gets fed up and wanders back to the KSC due to {1}", crewMember.name, reason);
                     LifeSupportManager.Instance.UntrackKerbal(crewMember.name);
                     crewMember.rosterStatus = ProtoCrewMember.RosterStatus.Available;
-                    DestroyVessel(vessel);
+                    vessel.Die();
                     break;
                 case 4: //Despawn
                     screenMessage = string.Format("{0} has gone missing due to {1}", crewMember.name, reason);
                     LifeSupportManager.Instance.UntrackKerbal(crewMember.name);
                     crewMember.rosterStatus = ProtoCrewMember.RosterStatus.Missing;
-                    DestroyVessel(vessel);
+                    vessel.Die();
                     break;
                 case 5: //Kill
                     screenMessage = string.Format("{0} has died due to {1}", crewMember.name, reason);
                     LifeSupportManager.Instance.UntrackKerbal(crewMember.name);
                     crewMember.rosterStatus = ProtoCrewMember.RosterStatus.Dead;
-                    DestroyVessel(vessel);
+                    vessel.Die();
                     break;
             }
 

--- a/Source/USILifeSupport/USILifeSupport.csproj
+++ b/Source/USILifeSupport/USILifeSupport.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\KSP_DEV\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\Kerbal Space Program\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -42,31 +42,31 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\KSP_DEV\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>..\..\..\..\KSP_DEV\KSP_x64_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\KSP_DEV\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>..\..\..\..\KSP_DEV\KSP_x64_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\..\..\..\KSP_DEV\KSP_x64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\KSP_DEV\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="USITools">
-      <HintPath>..\..\..\..\KSP_DEV\GameData\000_USITools\USITools.dll</HintPath>
+      <HintPath>..\..\..\..\Desktop\Kerbal Space Program\GameData\000_USITools\USITools.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
@@ -95,7 +95,11 @@
     <Compile Include="USILS_KolonyGrowthModule.cs" />
     <Compile Include="VesselSupplyStatus.cs" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
+  </ItemGroup>
+
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent Condition="'$(OS)' != 'Unix'">"D:\Games\pdb2mdb\pdb2mdb.exe" "$(TargetFileName)"
 </PostBuildEvent>


### PR DESCRIPTION
In response to #199 I put together a (shaky, experimental) revamp of the habitation time system in such a way as to support _almost_ everything that issue explains. Testing suggests everything works as intended, though I have not been totally rigorous with these.

The principle is that instead of resetting hab and home timers whenever a Kerbal switches vehicles or the like, each Kerbal has a personal cabin timer, which caps at the BaseHabTime in the settings panel, and a "how long have I been in space timer" of (now - LastAtHome) which is compared against whatever the current vessel's hab duration is. (That duration is calculated the same way as before, *minus* the BaseHabTime per seat times hab multiplier, which is going into the cabin time extension. Think of it a little like supply time vs. starving time now.)

A Kerbal only feels "comfortable" when their current vessel's hab duration is longer than they've spent in space so far. This means that when you put a Kerbal in a huge fancy LKO station and then send them on a trip to Eeloo in a tiny ship with one Hitchhiker, they'll only care about the tiny ship's habitation value for the journey. (Think of it as Kerbals getting harder to please the longer they've been away from home.)

Once a Kerbal no longer feels comfortable with current habitation, their cabin timer starts counting down; at 0 they take the homesickness penalty. This timer counts down slower if there are more empty seats in the vessel (this is where the BaseHabTime per seat went) or if the vessel has a HabMultiplier, and it gradually counts _up_ (to the cap) if they're comfortable in hab space again, thus allowing you to send a Kerbal on multiple few-days-long expeditions out of a central large mothership.

This approach thus keeps the flexibility of the old home timer setup in allowing Kerbals to depart from motherships on short trips, while preventing abuse (or just confusing numbers on the monitor!) from, e.g., briefly taking Kerbals out of a large vessel to boost the others' home timers as if they were the only ones onboard.

Issues at the moment:

- Kerbals in an unloaded vessel will not update their displayed cabin time until it's loaded again. (However, the catchup mechanic will correctly adjust for the amount of elapsed time at that point.)
- EVA Kerbals whose cabin timer completely drained while unloaded will correctly take the homesickness effect when loaded again, but no message will display onscreen.

Non-revamp parts of this might also be useful: commit f9d3e57 fixes #316, commit 846dba1 fixes #307 (turns out you should use vessel.Die() on an EVA Kerbal), commit 5481815 fixes #239, and the rest of this fork also corrects a few small typos. As such I don't expect this whole thing to be merged, it's more of a personal testbed.